### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ghostscript>=0.6
+ghostscript>=0.6,<=9.18
 numpy>=1.16.1
 pandas>=0.24.0
 pytest>=4.2.0


### PR DESCRIPTION
This is to pin the `ghostscript` requirements to `>=0.6` and `<=9.18`. Any newer versions cause an error due to font issues.